### PR TITLE
[Feat] #7: 회원가입 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,10 +48,22 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    //레디스
+    // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    //테스트
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.0.5'
+    implementation 'com.sun.mail:jakarta.mail:2.0.1'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // Test
     testImplementation "org.testcontainers:mysql:1.19.8"
     testImplementation "org.testcontainers:testcontainers:1.19.8"
     testImplementation 'org.testcontainers:junit-jupiter:1.19.8'

--- a/src/main/java/org/example/ctrlu/domain/auth/application/AuthService.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/application/AuthService.java
@@ -1,0 +1,93 @@
+package org.example.ctrlu.domain.auth.application;
+
+import static org.example.ctrlu.domain.auth.exception.AuthErrorCode.*;
+import static org.example.ctrlu.domain.user.exception.UserErrorCode.*;
+
+import java.util.Optional;
+
+import org.example.ctrlu.domain.auth.dto.request.SignupRequest;
+import org.example.ctrlu.domain.auth.exception.AuthException;
+import org.example.ctrlu.domain.auth.util.JWTUtil;
+import org.example.ctrlu.domain.user.entity.User;
+import org.example.ctrlu.domain.user.entity.UserStatus;
+import org.example.ctrlu.domain.user.exception.UserException;
+import org.example.ctrlu.domain.user.repository.UserRepository;
+import org.example.ctrlu.global.s3.AwsS3Service;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final AwsS3Service awsS3Service;
+	private final MailService mailService;
+	private final JWTUtil jwtUtil;
+
+	@Transactional
+	public void signup(SignupRequest signupRequest, MultipartFile file) {
+		Optional<User> optionalUser = userRepository.findByEmail(signupRequest.email());
+
+		if (optionalUser.isPresent()) {
+			User user = optionalUser.get();
+			handleExistingUser(signupRequest, file, user);
+			return;
+		}
+
+		createNewUser(signupRequest, file);
+	}
+
+	private void handleExistingUser(SignupRequest signupRequest, MultipartFile file, User user) {
+		if (user.getStatus() == UserStatus.ACTIVE) {
+			throw new AuthException(ALREADY_EXIST_EMAIL);
+		}
+
+		if (user.getStatus() == UserStatus.NONCERTIFIED && !jwtUtil.isExpired(user.getVerifyToken())) {
+			throw new AuthException(TRY_EMAIL_VERIFICATION);
+		}
+
+		// 사용자 정보 갱신 후 이메일 전송
+		restoreAndSendEmail(signupRequest, file, user);
+	}
+
+	private void restoreAndSendEmail(SignupRequest signupRequest, MultipartFile file, User user) {
+		String imageUrl = awsS3Service.uploadImage(file);
+		String encodedPassword = passwordEncoder.encode(signupRequest.password());
+		user.restore(encodedPassword, signupRequest.nickname(), imageUrl, jwtUtil.createVerifyToken());
+		mailService.sendEmail(user);
+	}
+
+	private void createNewUser(SignupRequest request, MultipartFile file) {
+		String imageUrl = awsS3Service.uploadImage(file);
+		String encodedPassword = passwordEncoder.encode(request.password());
+
+		User newUser = User.builder()
+			.email(request.email())
+			.password(encodedPassword)
+			.nickname(request.nickname())
+			.image(imageUrl)
+			.verifyToken(jwtUtil.createVerifyToken())
+			.build();
+
+		userRepository.save(newUser);
+		mailService.sendEmail(newUser);
+	}
+
+	@Transactional
+	public boolean verifyEmail(String verifyToken) {
+		if (jwtUtil.isExpired(verifyToken)) {
+			return false;
+		}
+
+		User user = userRepository.findByVerifyToken(verifyToken)
+			.orElseThrow(() -> new UserException(USER_NOT_FOUND));
+
+		user.updateStatus(UserStatus.ACTIVE);
+		return true;
+	}
+}

--- a/src/main/java/org/example/ctrlu/domain/auth/application/AuthService.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/application/AuthService.java
@@ -85,7 +85,7 @@ public class AuthService {
 		}
 
 		User user = userRepository.findByVerifyToken(verifyToken)
-			.orElseThrow(() -> new UserException(USER_NOT_FOUND));
+			.orElseThrow(() -> new UserException(NOT_FOUND_USER));
 
 		user.updateStatus(UserStatus.ACTIVE);
 		return true;

--- a/src/main/java/org/example/ctrlu/domain/auth/application/MailService.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/application/MailService.java
@@ -1,0 +1,94 @@
+package org.example.ctrlu.domain.auth.application;
+
+import static org.example.ctrlu.domain.auth.exception.AuthErrorCode.*;
+
+import java.io.UnsupportedEncodingException;
+
+import org.example.ctrlu.domain.auth.exception.AuthException;
+import org.example.ctrlu.domain.user.entity.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MailService {
+	private static final String EMAIL_CERTIFICATION_SUBJECT = "CtrlU 회원가입 이메일 인증";
+	private static final String CHARSET = "utf-8";
+	private static final String SUBTYPE = "html";
+	private static final String SENDER = "CtrlU";
+	private static final String BODY =
+        """
+        <body>
+            <div style="width: 592px">
+                <img src="https://inandout-bucket.s3.ap-northeast-2.amazonaws.com/logo.svg" />
+                <div style="margin: 0 20px">
+                    <div style="font-size: 40px; font-weight: 700; margin-top: 32px">
+                        회원가입을 위한<br />
+                        가장 마지막 절차예요!
+                    </div>
+                    <div style="
+                        color: #b4b4b4;
+                        font-size: 22px;
+                        font-weight: 500;
+                        margin-top: 16px;">
+                        메일 확인과 개인정보보호를 위해 인증절차를 진행하고 있어요.<br />
+                        인증 버튼을 눌러 회원가입을 완료해주세요.
+                    </div>
+                    <a href="%s">
+                        <button style="
+                            margin-top: 80px;
+                            background-color: black;
+                            color: white;
+                            border: none;
+                            border-radius: 99px;
+                            width: 100%%;
+                            height: 80px;
+                            font-size: 22px;
+                            cursor: pointer;">
+                            메일 인증하기
+                        </button>
+                    </a>
+                    <div style="
+                        color: #b4b4b4;
+                        font-size: 22px;
+                        font-weight: 500;
+                        margin-top: 120px;">
+                        * 본 메일은 발신전용으로 회신이 불가능합니다.
+                    </div>
+                </div>
+            </div>
+        </body>
+        """;
+
+	@Value("${spring.mail.username}")
+	private String email;
+	@Value("${spring.mail.request-uri}")
+	private String requestUri;
+
+	private final JavaMailSender mailSender;
+
+	public void sendEmail(User user) {
+		String receiverMail = user.getEmail();
+		MimeMessage message = mailSender.createMimeMessage();
+
+		try {
+			message.addRecipients(MimeMessage.RecipientType.TO, receiverMail); // 보내는 대상
+			message.setSubject(EMAIL_CERTIFICATION_SUBJECT); // 제목
+			message.setText(getEmailCertificationBody(user), CHARSET, SUBTYPE); // 내용, charset 타입, subtype
+			message.setFrom(new InternetAddress(email, SENDER)); // 보내는 사람의 이메일 주소, 보내는 사람 이름
+			mailSender.send(message); // 메일 전송
+		} catch (MessagingException | UnsupportedEncodingException e) {
+			throw new AuthException(FAILED_SEND_EMAIL);
+		}
+	}
+
+	private String getEmailCertificationBody(User user) {
+		return BODY.formatted(requestUri + user.getVerifyToken());
+	}
+}

--- a/src/main/java/org/example/ctrlu/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package org.example.ctrlu.domain.auth.controller;
 
 import org.example.ctrlu.domain.auth.application.AuthService;
 import org.example.ctrlu.domain.auth.dto.request.SignupRequest;
+import org.example.ctrlu.global.response.BaseResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,11 +24,12 @@ public class AuthController {
 	private static final String ERROR_URL = "http://ctrlu.site/error";
 
 	@PostMapping("/signup")
-	public void signup(
+	public BaseResponse<Void> signup(
 		@RequestPart("request") @Valid SignupRequest request,
 		@RequestPart("userImage") MultipartFile userImage
 	) {
 		authService.signup(request, userImage);
+		return new BaseResponse<>(null);
 	}
 
 	@GetMapping("/verify")

--- a/src/main/java/org/example/ctrlu/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/controller/AuthController.java
@@ -1,0 +1,43 @@
+package org.example.ctrlu.domain.auth.controller;
+
+import org.example.ctrlu.domain.auth.application.AuthService;
+import org.example.ctrlu.domain.auth.dto.request.SignupRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.view.RedirectView;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+	private final AuthService authService;
+	private static final String LOGIN_URL = "http://ctrlu.site/login";
+	private static final String ERROR_URL = "http://ctrlu.site/error";
+
+	@PostMapping("/signup")
+	public void signup(
+		@RequestPart("request") @Valid SignupRequest request,
+		@RequestPart("userImage") MultipartFile userImage
+	) {
+		authService.signup(request, userImage);
+	}
+
+	@GetMapping("/verify")
+	public Object verifyEmail(@RequestParam("token") String token) {
+		boolean isComplete = authService.verifyEmail(token);
+
+		if (isComplete) {
+			return new RedirectView(LOGIN_URL);
+		} else {
+			return new RedirectView(ERROR_URL);  // 링크 만료 페이지로 이동
+		}
+	}
+}

--- a/src/main/java/org/example/ctrlu/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/dto/request/SignupRequest.java
@@ -1,0 +1,15 @@
+package org.example.ctrlu.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequest (
+	@NotBlank
+	@Email(message = "유효한 이메일 형식이어야 합니다.")
+	String email,
+	@NotBlank
+	String password,
+	@NotBlank
+	String nickname
+) {
+}

--- a/src/main/java/org/example/ctrlu/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,19 @@
+package org.example.ctrlu.domain.auth.exception;
+
+import org.example.ctrlu.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+	ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST.value(), "A001", "이미 존재하는 이메일입니다."),
+	FAILED_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "A002", "인증 메일 전송에 실패하였습니다."),
+	TRY_EMAIL_VERIFICATION(HttpStatus.BAD_REQUEST.value(), "A003", "이메일 인증을 해주세요.");
+
+	private final int status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/org/example/ctrlu/domain/auth/exception/AuthException.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package org.example.ctrlu.domain.auth.exception;
+
+import org.example.ctrlu.global.exception.BaseException;
+import org.example.ctrlu.global.response.ErrorCode;
+
+public class AuthException extends BaseException {
+	public AuthException(ErrorCode exceptionStatus) {
+		super(exceptionStatus);
+	}
+}

--- a/src/main/java/org/example/ctrlu/domain/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/exception/AuthExceptionHandler.java
@@ -1,0 +1,17 @@
+package org.example.ctrlu.domain.auth.exception;
+
+import org.example.ctrlu.global.response.BaseErrorResponse;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class AuthExceptionHandler {
+	@ExceptionHandler({AuthException.class})
+	public BaseErrorResponse handleAuthException(AuthException e) {
+		log.error("[handleAuthException]", e);
+		return new BaseErrorResponse(e.getExceptionStatus());
+	}
+}

--- a/src/main/java/org/example/ctrlu/domain/auth/util/JWTUtil.java
+++ b/src/main/java/org/example/ctrlu/domain/auth/util/JWTUtil.java
@@ -1,0 +1,50 @@
+package org.example.ctrlu.domain.auth.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+
+@Component
+public class JWTUtil {
+	private SecretKey secretKey;
+	private static final Long VERIFYTOKEN_EXPIRATION = 300000L; // 5분
+
+	public JWTUtil(@Value("${jwt.secret}") String secret) {
+		secretKey = new SecretKeySpec(
+						secret.getBytes(StandardCharsets.UTF_8),
+						Jwts.SIG.HS256.key().build().getAlgorithm()
+					);
+	}
+
+	public String createVerifyToken() {
+		return Jwts.builder()
+			.issuedAt(new Date(System.currentTimeMillis()))
+			.expiration(new Date(System.currentTimeMillis() + VERIFYTOKEN_EXPIRATION))
+			.signWith(secretKey)
+			.compact();
+	}
+
+	public Boolean isExpired(String token) {
+		try {
+			Date expiration = Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload()
+				.getExpiration();
+
+			return expiration.before(new Date());
+		} catch (ExpiredJwtException e) {
+			// 토큰이 만료된 경우 true 반환
+			return true;
+		}
+	}
+}

--- a/src/main/java/org/example/ctrlu/domain/friendship/exception/FriendshipErrorCode.java
+++ b/src/main/java/org/example/ctrlu/domain/friendship/exception/FriendshipErrorCode.java
@@ -12,6 +12,6 @@ public enum FriendshipErrorCode implements ErrorCode {
 	; // FriendshipErrorCode
 
 	private final int status;
-	private final int code;
+	private final String code;
 	private final String message;
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/exception/TodoErrorCode.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum TodoErrorCode implements ErrorCode {
-	ALREADY_EXIST_PROCEEDING_TODO(HttpStatus.BAD_REQUEST.value(),4001,"이미 진행중인 할 일이 존재합니다."),
-	NOT_FOUND_TODO(HttpStatus.BAD_REQUEST.value(),4002,"존재하지 않는 할 일입니다.")
+	ALREADY_EXIST_PROCEEDING_TODO(HttpStatus.BAD_REQUEST.value(),"T001","이미 진행중인 할 일이 존재합니다."),
+	NOT_FOUND_TODO(HttpStatus.BAD_REQUEST.value(),"T002","존재하지 않는 할 일입니다.")
 	;
 
 	private final int status;

--- a/src/main/java/org/example/ctrlu/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/exception/TodoErrorCode.java
@@ -14,6 +14,6 @@ public enum TodoErrorCode implements ErrorCode {
 	;
 
 	private final int status;
-	private final int code;
+	private final String code;
 	private final String message;
 }

--- a/src/main/java/org/example/ctrlu/domain/user/entity/User.java
+++ b/src/main/java/org/example/ctrlu/domain/user/entity/User.java
@@ -1,6 +1,5 @@
 package org.example.ctrlu.domain.user.entity;
 
-import java.time.LocalDateTime;
 import org.example.ctrlu.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -50,8 +49,15 @@ public class User extends BaseEntity {
 		this.status = UserStatus.NONCERTIFIED;
 	}
 
-	public void updateToken(String newToken) {
-		this.verifyToken = newToken;
+	public void restore(String password, String nickname, String image, String verifyToken) {
+		this.password = password;
+		this.nickname = nickname;
+		this.image = image;
+		this.verifyToken = verifyToken;
+		this.status = UserStatus.NONCERTIFIED;
 	}
 
+	public void updateStatus(UserStatus status) {
+		this.status = status;
+	}
 }

--- a/src/main/java/org/example/ctrlu/domain/user/entity/User.java
+++ b/src/main/java/org/example/ctrlu/domain/user/entity/User.java
@@ -1,16 +1,17 @@
 package org.example.ctrlu.domain.user.entity;
 
 import java.time.LocalDateTime;
-
-import lombok.Builder;
 import org.example.ctrlu.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,17 +34,24 @@ public class User extends BaseEntity {
 
 	private String image;
 
-	private LocalDateTime deletedAt;
+	private String verifyToken;
 
-	public void delete() {
-		this.deletedAt = LocalDateTime.now();
-	}
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private UserStatus status;
 
 	@Builder
-	public User(String email, String password, String nickname, String image) {
+	public User(String email, String password, String nickname, String image, String verifyToken) {
 		this.email = email;
 		this.password = password;
 		this.nickname = nickname;
 		this.image = image;
+		this.verifyToken = verifyToken;
+		this.status = UserStatus.NONCERTIFIED;
 	}
+
+	public void updateToken(String newToken) {
+		this.verifyToken = newToken;
+	}
+
 }

--- a/src/main/java/org/example/ctrlu/domain/user/entity/UserStatus.java
+++ b/src/main/java/org/example/ctrlu/domain/user/entity/UserStatus.java
@@ -1,0 +1,7 @@
+package org.example.ctrlu.domain.user.entity;
+
+public enum UserStatus {
+	ACTIVE,   // 가입
+	NONCERTIFIED, // 미인증
+	INACTIVE   // 탈퇴
+}

--- a/src/main/java/org/example/ctrlu/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/example/ctrlu/domain/user/exception/UserErrorCode.java
@@ -9,9 +9,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-	NOT_FOUND_USER(HttpStatus.BAD_REQUEST.value(),3001,"존재하지 않는 사용자입니다.");;
+	NOT_FOUND_USER(HttpStatus.BAD_REQUEST.value(),"U001","존재하지 않는 사용자입니다.");;
 
 	private final int status;
-	private final int code;
+	private final String code;
 	private final String message;
 }

--- a/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
@@ -1,7 +1,11 @@
 package org.example.ctrlu.domain.user.repository;
 
+import java.util.Optional;
+
 import org.example.ctrlu.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User,Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByEmail(String email);
+	Optional<User> findByVerifyToken(String verifyToken);
 }

--- a/src/main/java/org/example/ctrlu/global/config/SecutiryConfig.java
+++ b/src/main/java/org/example/ctrlu/global/config/SecutiryConfig.java
@@ -1,0 +1,31 @@
+package org.example.ctrlu.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecutiryConfig {
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/auth/**").permitAll()
+				.anyRequest().authenticated()
+			);
+
+		return http.build();
+	}
+}

--- a/src/main/java/org/example/ctrlu/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/ctrlu/global/exception/GlobalExceptionHandler.java
@@ -26,13 +26,13 @@ public class GlobalExceptionHandler {
 
 		return new BaseErrorResponse(new ErrorCode() {
 			@Override
-			public int getCode() {
-				return 2001;
+			public int getStatus() {
+				return HttpStatus.BAD_REQUEST.value();
 			}
 
 			@Override
-			public int getStatus() {
-				return HttpStatus.BAD_REQUEST.value();
+			public String getCode() {
+				return "B003";
 			}
 
 			@Override

--- a/src/main/java/org/example/ctrlu/global/response/BaseErrorCode.java
+++ b/src/main/java/org/example/ctrlu/global/response/BaseErrorCode.java
@@ -2,36 +2,16 @@ package org.example.ctrlu.global.response;
 
 import org.springframework.http.HttpStatus;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum BaseErrorCode implements ErrorCode {
-	/**
-	 * 1000: 요청 성공 (OK)
-	 */
-	SUCCESS(1000, HttpStatus.OK.value(), "요청에 성공하였습니다."),
+	SUCCESS(HttpStatus.OK.value(), "B001", "요청에 성공하였습니다."),
+	ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST.value(), "B002", "잘못된 파라미터 타입입니다.");
 
-	/**
-	 * 2000: 요청 실패
-	 */
-	ARGUMENT_TYPE_MISMATCH(2002, HttpStatus.BAD_REQUEST.value(), "잘못된 파라미터 타입입니다.");
-
-	private final int code;
 	private final int status;
+	private final String code;
 	private final String message;
-
-	@Override
-	public int getCode() {
-		return code;
-	}
-
-	@Override
-	public int getStatus() {
-		return status;
-	}
-
-	@Override
-	public String getMessage() {
-		return message;
-	}
 }

--- a/src/main/java/org/example/ctrlu/global/response/BaseErrorResponse.java
+++ b/src/main/java/org/example/ctrlu/global/response/BaseErrorResponse.java
@@ -7,30 +7,15 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-@JsonPropertyOrder({"code", "status", "message", "timestamp"})
+@JsonPropertyOrder({"status", "code", "message", "timestamp"})
 public class BaseErrorResponse implements ErrorCode {
-	private final int code;
 	private final int status;
+	private final String code;
 	private final String message;
 
 	public BaseErrorResponse(ErrorCode status){
-		this.code = status.getCode();
 		this.status = status.getStatus();
+		this.code = status.getCode();
 		this.message = status.getMessage();
-	}
-
-	@Override
-	public int getCode() {
-		return code;
-	}
-
-	@Override
-	public int getStatus() {
-		return status;
-	}
-
-	@Override
-	public String getMessage() {
-		return message;
 	}
 }

--- a/src/main/java/org/example/ctrlu/global/response/BaseResponse.java
+++ b/src/main/java/org/example/ctrlu/global/response/BaseResponse.java
@@ -11,10 +11,10 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
 @Getter
-@JsonPropertyOrder({"code", "status", "message", "result"})
+@JsonPropertyOrder({"status", "code", "message", "result"})
 public class BaseResponse<T> implements ErrorCode {
-	private final int code;
 	private final int status;
+	private final String code;
 	private final String message;
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
@@ -22,24 +22,9 @@ public class BaseResponse<T> implements ErrorCode {
 
 	@JsonCreator
 	public BaseResponse(T result){
-		this.code = SUCCESS.getCode();
 		this.status = SUCCESS.getStatus();
+		this.code = SUCCESS.getCode();
 		this.message = SUCCESS.getMessage();
 		this.result = result;
-	}
-
-	@Override
-	public int getCode() {
-		return code;
-	}
-
-	@Override
-	public int getStatus() {
-		return status;
-	}
-
-	@Override
-	public String getMessage() {
-		return message;
 	}
 }

--- a/src/main/java/org/example/ctrlu/global/response/ErrorCode.java
+++ b/src/main/java/org/example/ctrlu/global/response/ErrorCode.java
@@ -1,7 +1,7 @@
 package org.example.ctrlu.global.response;
 
 public interface ErrorCode {
-	int getCode();
 	int getStatus();
+	String getCode();
 	String getMessage();
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
     time-zone: Asia/Seoul
 
 ---
+
 cloud:
   aws:
     credentials:
@@ -19,6 +20,9 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
 
 ---
 
@@ -51,6 +55,25 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  mail:
+    port: 465
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_APP_PASSWORD}
+    host: ${EMAIL_HOST}
+    request-uri: ${EMAIL_REQUEST_URI}
+    default-encoding: UTF-8
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: false
+          ssl:
+            enable: true
+            trust: ${EMAIL_HOST}
+        transport:
+          protocol: smtp
+        debug: true
 
 ---
 
@@ -79,6 +102,25 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  mail:
+    port: 465
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_APP_PASSWORD}
+    host: ${EMAIL_HOST}
+    request-uri: ${EMAIL_REQUEST_URI}
+    default-encoding: UTF-8
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: false
+          ssl:
+            enable: true
+            trust: ${EMAIL_HOST}
+        transport:
+          protocol: smtp
+        debug: true
 
 ---
 

--- a/src/test/java/org/example/ctrlu/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/auth/application/AuthServiceTest.java
@@ -1,0 +1,7 @@
+package org.example.ctrlu.domain.auth.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthServiceTest {
+
+}

--- a/src/test/java/org/example/ctrlu/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/auth/application/AuthServiceTest.java
@@ -1,7 +1,197 @@
 package org.example.ctrlu.domain.auth.application;
 
+import static org.example.ctrlu.domain.auth.exception.AuthErrorCode.*;
+import static org.example.ctrlu.domain.user.exception.UserErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
+import org.example.ctrlu.domain.auth.dto.request.SignupRequest;
+import org.example.ctrlu.domain.auth.exception.AuthException;
+import org.example.ctrlu.domain.auth.util.JWTUtil;
+import org.example.ctrlu.domain.user.entity.User;
+import org.example.ctrlu.domain.user.entity.UserStatus;
+import org.example.ctrlu.domain.user.exception.UserException;
+import org.example.ctrlu.domain.user.repository.UserRepository;
+import org.example.ctrlu.global.s3.AwsS3Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
+	public static final String VERIFY_TOKEN = "verify_token";
+	public static final String EXPIRED_TOKEN = "expired_token";
+	public static final String ENCODED_PASSWORD = "encoded_password";
+	public static final String IMAGE_URL = "http://s3.com/image.png";
 
+	@InjectMocks
+	private AuthService authService;
+	@Mock
+	private MailService mailService;
+	@Mock
+	private AwsS3Service awsS3Service;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private PasswordEncoder passwordEncoder;
+	@Mock
+	private JWTUtil jwtUtil;
+	@Mock
+	private MultipartFile file;
+
+	private SignupRequest signupRequest;
+
+	@BeforeEach
+	void setUp() {
+		signupRequest = new SignupRequest("email@gmail.com", "password", "nickname");
+	}
+
+	@Test
+	@DisplayName("회원가입 시 사용자가 존재하지 않으면 새로운 사용자를 생성한다.")
+	void signup_ShouldCreateNewUser_WhenEmailNotExists() {
+		// given
+		when(userRepository.findByEmail(signupRequest.email())).thenReturn(Optional.empty());
+		when(awsS3Service.uploadImage(file)).thenReturn(IMAGE_URL);
+		when(passwordEncoder.encode(signupRequest.password())).thenReturn(ENCODED_PASSWORD);
+		when(jwtUtil.createVerifyToken()).thenReturn(VERIFY_TOKEN);
+
+		// when
+		authService.signup(signupRequest, file);
+
+		// then
+		verify(userRepository).save(any(User.class));
+		verify(mailService).sendEmail(any(User.class));
+	}
+
+	@Test
+	@DisplayName("회원가입 시 사용자가 존재하고 인증된 상태라면 예외가 발생한다.")
+	void signup_ShouldThrowException_WhenEmailAlreadyActive() {
+		// given
+		User user = User.builder().build();
+		ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
+		when(userRepository.findByEmail(signupRequest.email())).thenReturn(Optional.of(user));
+
+		// when / then
+		AuthException authException =
+			assertThrows(AuthException.class, () -> authService.signup(signupRequest, file));
+		assertEquals(ALREADY_EXIST_EMAIL, authException.getExceptionStatus());
+	}
+
+	@Test
+	@DisplayName("회원가입 시 사용자가 존재하지만 인증 전 상태이고 이전 토큰 만료되지 않았다면 예외가 발생한다.")
+	void signup_ShouldThrowException_WhenUserNonCertifiedAndTokenNotExpired() {
+		// given
+		User user = User.builder().build();
+		ReflectionTestUtils.setField(user, "status", UserStatus.NONCERTIFIED);
+		ReflectionTestUtils.setField(user, "verifyToken", VERIFY_TOKEN);
+
+		when(jwtUtil.isExpired(VERIFY_TOKEN)).thenReturn(false);
+		when(userRepository.findByEmail(signupRequest.email())).thenReturn(Optional.of(user));
+
+		// when / then
+		AuthException authException =
+			assertThrows(AuthException.class, () -> authService.signup(signupRequest, file));
+		assertEquals(TRY_EMAIL_VERIFICATION, authException.getExceptionStatus());
+	}
+
+	@Test
+	@DisplayName("회원가입 시 사용자가 존재하지만 인증 전 상태이고 이전 토큰 만료되었다면 사용자를 갱신하고 인증 메일을 보낸다.")
+	void signup_ShouldRestoreUser_WhenTokenExpired() {
+		// given
+		User user = User.builder().build();
+		ReflectionTestUtils.setField(user, "status", UserStatus.NONCERTIFIED);
+		ReflectionTestUtils.setField(user, "verifyToken", EXPIRED_TOKEN);
+
+		when(userRepository.findByEmail(signupRequest.email())).thenReturn(Optional.of(user));
+		when(jwtUtil.isExpired(EXPIRED_TOKEN)).thenReturn(true);
+		when(awsS3Service.uploadImage(file)).thenReturn(IMAGE_URL);
+		when(passwordEncoder.encode(signupRequest.password())).thenReturn(ENCODED_PASSWORD);
+		when(jwtUtil.createVerifyToken()).thenReturn(VERIFY_TOKEN);
+
+		// when
+		authService.signup(signupRequest, file);
+
+		// then
+		assertEquals(ENCODED_PASSWORD, user.getPassword());
+		assertEquals(signupRequest.nickname(), user.getNickname());
+		assertEquals(IMAGE_URL, user.getImage());
+		assertEquals(VERIFY_TOKEN, user.getVerifyToken());
+		verify(mailService).sendEmail(user);
+	}
+
+	@Test
+	@DisplayName("회원가입 시 사용자가 존재하지만 탈퇴 상태라면 사용자를 갱신하고 인증 메일을 보낸다.")
+	void signup_ShouldRestoreUser_WhenUserInActive() {
+		// given
+		User user = User.builder().build();
+		ReflectionTestUtils.setField(user, "status", UserStatus.INACTIVE);
+		ReflectionTestUtils.setField(user, "verifyToken", EXPIRED_TOKEN);
+
+		when(userRepository.findByEmail(signupRequest.email())).thenReturn(Optional.of(user));
+		when(awsS3Service.uploadImage(file)).thenReturn(IMAGE_URL);
+		when(passwordEncoder.encode(signupRequest.password())).thenReturn(ENCODED_PASSWORD);
+		when(jwtUtil.createVerifyToken()).thenReturn(VERIFY_TOKEN);
+
+		// when
+		authService.signup(signupRequest, file);
+
+		// then
+		assertEquals(ENCODED_PASSWORD, user.getPassword());
+		assertEquals(signupRequest.nickname(), user.getNickname());
+		assertEquals(IMAGE_URL, user.getImage());
+		assertEquals(VERIFY_TOKEN, user.getVerifyToken());
+		verify(mailService).sendEmail(user);
+	}
+
+	@Test
+	@DisplayName("이메일 인증 시 토큰이 유효하면 true를 반환한다.")
+	void verifyEmail_ShouldReturnTrue_WhenTokenValid() {
+		// given
+		User user = User.builder().build();
+		when(jwtUtil.isExpired(VERIFY_TOKEN)).thenReturn(false);
+		when(userRepository.findByVerifyToken(VERIFY_TOKEN)).thenReturn(Optional.of(user));
+
+		// when
+		boolean result = authService.verifyEmail(VERIFY_TOKEN);
+
+		// then
+		assertTrue(result);
+		assertEquals(UserStatus.ACTIVE, user.getStatus());
+	}
+
+	@Test
+	@DisplayName("이메일 인증 시 토큰이 만료됐으면 false를 반환한다.")
+	void verifyEmail_ShouldReturnFalse_WhenTokenExpired() {
+		// given
+		when(jwtUtil.isExpired(EXPIRED_TOKEN)).thenReturn(true);
+
+		// when
+		boolean result = authService.verifyEmail(EXPIRED_TOKEN);
+
+		// then
+		assertFalse(result);
+		verify(userRepository, never()).findByVerifyToken(any());
+	}
+
+	@Test
+	@DisplayName("이메일 인증 시 사용자가 존재하지 않으면 예외를 발생시킨다.")
+	void verifyEmail_ShouldThrowException_WhenNotFoundUser() {
+		// given
+		when(jwtUtil.isExpired(VERIFY_TOKEN)).thenReturn(false);
+		when(userRepository.findByVerifyToken(VERIFY_TOKEN)).thenReturn(Optional.empty());
+
+		// when / then
+		UserException userException =
+			assertThrows(UserException.class, () -> authService.verifyEmail(VERIFY_TOKEN));
+		assertEquals(NOT_FOUND_USER, userException.getExceptionStatus());
+	}
 }

--- a/src/test/java/org/example/ctrlu/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/example/ctrlu/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,113 @@
+package org.example.ctrlu.domain.auth.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.example.ctrlu.config.TestMySQLConfig;
+import org.example.ctrlu.domain.auth.application.AuthService;
+import org.example.ctrlu.domain.auth.application.MailService;
+import org.example.ctrlu.domain.auth.dto.request.SignupRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Testcontainers
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AuthControllerTest {
+	private static final String LOGIN_URL = "http://ctrlu.site/login";
+	private static final String ERROR_URL = "http://ctrlu.site/error";
+	@Autowired
+	private MockMvc mockMvc;
+	@MockitoBean
+	private MailService mailService;
+	@MockitoBean
+	private AuthService authService;
+	@Autowired
+	private ObjectMapper objectMapper;
+	static final MySQLContainer<?> mySQLContainer = TestMySQLConfig.MYSQL_CONTAINER;
+
+	@DynamicPropertySource
+	public static void overrideProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
+		registry.add("spring.datasource.username", mySQLContainer::getUsername);
+		registry.add("spring.datasource.password", mySQLContainer::getPassword);
+		registry.add("spring.datasource.driver-class-name", mySQLContainer::getDriverClassName);
+	}
+
+	@Test
+	@DisplayName("회원가입에 성공한다.")
+	void signup_success() throws Exception {
+		// given
+		SignupRequest request = new SignupRequest("test1@example.com", "password123!", "tester");
+		String requestJson = objectMapper.writeValueAsString(request);
+
+		MockMultipartFile imageFile = new MockMultipartFile(
+			"request",
+			"request.json",
+			"application/json",
+			requestJson.getBytes(StandardCharsets.UTF_8)
+		);
+
+		MockMultipartFile jsonPart = new MockMultipartFile(
+			"userImage",
+			"profile.png",
+			"image/png",
+			"fake image content".getBytes()
+		);
+
+		// when & then
+		mockMvc.perform(multipart("/auth/signup")
+				.file(jsonPart)
+				.file(imageFile)
+				.contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("이메일 인증 성공 시 로그인 페이지로 리다이렉트한다.")
+	void verifyEmail_ShouldRedirectToLogin_WhenSuccess() throws Exception {
+		// given
+		String token = "valid_token";
+		when(authService.verifyEmail(token)).thenReturn(true);
+
+		// when + then
+		mockMvc.perform(get("/auth/verify").param("token", token))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl(LOGIN_URL));
+	}
+
+	@Test
+	@DisplayName("이메일 인증 실패 시 만료 페이지로 리다이렉트한다.")
+	void verifyEmail_ShouldRedirectToError_WhenFailed() throws Exception {
+		// given
+		String token = "expired_token";
+		when(authService.verifyEmail(token)).thenReturn(false);
+
+		// when + then
+		mockMvc.perform(get("/auth/verify").param("token", token))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl(ERROR_URL));
+	}
+}

--- a/src/test/java/org/example/ctrlu/domain/todo/controller/CreateTodoControllerTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/controller/CreateTodoControllerTest.java
@@ -2,6 +2,7 @@ package org.example.ctrlu.domain.todo.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.ctrlu.config.TestMySQLConfig;
+import org.example.ctrlu.domain.auth.application.MailService;
 import org.example.ctrlu.domain.todo.dto.request.CreateTodoRequest;
 import org.example.ctrlu.domain.todo.repository.TodoRepository;
 import org.example.ctrlu.domain.user.entity.User;
@@ -54,6 +55,9 @@ class CreateTodoControllerTest {
 
     @MockitoBean
     private AwsS3Service awsS3Service;
+
+    @MockitoBean
+    private MailService mailService;
 
     //todo: Mock으로 하면 ConnectionFactory must not be null 오류가 남. 다른 이유를 모르겠음.
 //    @MockitoBean

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
@@ -23,3 +23,6 @@ cloud:
       static: FAKE
     stack:
       auto: false
+
+jwt:
+  secret: FAKE


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
Resolves #7
closed #7 

## 📌 개요
- 회원가입 api 구현
- 이메일 인증
- 구현 로직
  - 사용자가 존재하지 않을 때: `새로운 사용자 생성하고, 저장 후, 인증 이메일 보냄`
  - 사용자가 존재하고 인증된 상태: `ALREADY_EXIST_EMAIL`
  - 사용자가 존재하지만 인증 전 상태, 이전 토큰 만료 전: `FAILED_EMAIL_VERIFICATION`
  - 사용자가 존재하지만 인증 전 상태, 이전 토큰 만료: `새로 입력받은 정보로 사용자 정보 갱신 후, 토큰 재발급하고 인증 이메일 다시 보냄` 
  - 사용자가 존재하지만 탈퇴 상태: `사용자 상태 NONCERTIFIED로 복구한 후, 새로 입력받은 정보로 사용자 정보 갱신 후, 토큰 재발급하고 인증 이메일 다시 보냄`

## 📝 PR 유형
기능 추가

## ✔ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 💬 팀원에게 전할 말
- 현재 인증/인가 작업이 안되어있어서 CreateTodoControllerTest가 403으로 실패합니다.
- JWT랑 이메일 관련 환경변수 로컬에 추가해주세요.