### PR TITLE
[Feat] #15: 24시간 내 등록된 할 일 관련 API 및 테스트 코드 구현

### DIFF
--- a/src/main/java/org/example/ctrlu/domain/friendship/entity/Friendship.java
+++ b/src/main/java/org/example/ctrlu/domain/friendship/entity/Friendship.java
@@ -1,5 +1,6 @@
 package org.example.ctrlu.domain.friendship.entity;
 
+import lombok.Builder;
 import org.example.ctrlu.domain.user.entity.User;
 import org.example.ctrlu.global.entity.BaseEntity;
 
@@ -36,4 +37,15 @@ public class Friendship extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "to_user_id", nullable = false)
 	private User toUser;
+
+	@Builder
+	public Friendship(User fromUser, User toUser) {
+		this.fromUser = fromUser;
+		this.toUser = toUser;
+		this.status = FriendshipStatus.PENDING;
+	}
+
+	public void accept() {
+		this.status = FriendshipStatus.ACCEPTED;
+	}
 }

--- a/src/main/java/org/example/ctrlu/domain/friendship/repository/FriendShipRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/friendship/repository/FriendShipRepository.java
@@ -3,6 +3,7 @@ package org.example.ctrlu.domain.friendship.repository;
 import org.example.ctrlu.domain.friendship.entity.Friendship;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -16,5 +17,5 @@ public interface FriendShipRepository extends JpaRepository<Friendship,Long> {
     WHERE (f.fromUser.id = :userId OR f.toUser.id = :userId)
       AND f.status = 'ACCEPTED'
     """)
-    List<Long> findAcceptedFriendIds(long userId);
+    List<Long> findAcceptedFriendIds(@Param("userId") long userId);
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/application/TodoService.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/application/TodoService.java
@@ -181,11 +181,7 @@ public class TodoService {
         String myProfileImage = userRepository.getImageById(userId);
         GetRecentUploadFriendsResponse.Status status;
         boolean exists = todoRepository.existsByUserIdAndCreatedAtAfterAndStatusNot(userId, now.minusHours(24), TodoStatus.GIVEN_UP);
-        if (exists) {
-            status = GetRecentUploadFriendsResponse.Status.GRAY;
-        } else {
-            status = GetRecentUploadFriendsResponse.Status.NONE;
-        }
+        status = exists ? GetRecentUploadFriendsResponse.Status.GRAY : GetRecentUploadFriendsResponse.Status.NONE;
 
         GetRecentUploadFriendsResponse.Me me = new GetRecentUploadFriendsResponse.Me(
                 userId,

--- a/src/main/java/org/example/ctrlu/domain/todo/application/TodoService.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/application/TodoService.java
@@ -42,7 +42,7 @@ public class TodoService {
     private final FriendShipRepository friendShipRepository;
     private final Clock clock;
     private final RedisTemplate<String,Object> redisTemplate;
-    private static final String REDIS_KEY_PREFIX = "story:seen:";
+    private static final String REDIS_KEY_PREFIX = "recentTodo:seen:";
 
     protected LocalDateTime now() {
         return LocalDateTime.now(clock);
@@ -156,7 +156,7 @@ public class TodoService {
             long friendId = todo.getUser().getId();
             long latestTodoId = todo.getId();
 
-            String seenTodoIdStr = (String) redisTemplate.opsForHash().get(redisKey, String.valueOf(friendId));
+            String seenTodoIdStr = (String)redisTemplate.opsForHash().get(redisKey, String.valueOf(friendId));
             long seenTodoId = seenTodoIdStr != null ? Long.parseLong(seenTodoIdStr) : -1;
 
             GetRecentUploadFriendsResponse.Status status = seenTodoId < latestTodoId
@@ -204,7 +204,7 @@ public class TodoService {
 
     @Transactional(readOnly = true)
     public GetRecentUploadTodoResponse getRecentUploadTodo(long userId, long targetId, long nowId) {
-        String redisKey = "recentTodo:seen:" + userId;
+        String redisKey = REDIS_KEY_PREFIX + userId;
         String seenValue = (String) redisTemplate.opsForHash().get(redisKey, String.valueOf(targetId));
 
         //target의 최근 24시간 내 등록된 할 일(오래된 순) 조회

--- a/src/main/java/org/example/ctrlu/domain/todo/application/TodoService.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/application/TodoService.java
@@ -180,10 +180,10 @@ public class TodoService {
     private GetRecentUploadFriendsResponse.Me setMyData(long userId, LocalDateTime now) {
         String myProfileImage = userRepository.getImageById(userId);
         GetRecentUploadFriendsResponse.Status status;
-        List<Todo> todosWithin24 = todoRepository.findByUserIdAndCreatedAtAfterAndStatusNot(userId, now.minusHours(24), TodoStatus.GIVEN_UP);
-        if(!todosWithin24.isEmpty()) {
-           status = GetRecentUploadFriendsResponse.Status.GRAY;
-        } else{
+        boolean exists = todoRepository.existsByUserIdAndCreatedAtAfterAndStatusNot(userId, now.minusHours(24), TodoStatus.GIVEN_UP);
+        if (exists) {
+            status = GetRecentUploadFriendsResponse.Status.GRAY;
+        } else {
             status = GetRecentUploadFriendsResponse.Status.NONE;
         }
 

--- a/src/main/java/org/example/ctrlu/domain/todo/application/TodoService.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/application/TodoService.java
@@ -24,10 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -174,8 +171,22 @@ public class TodoService {
                     status
             ));
         }
-        return responseFriends;
+
+        // 초록색 상태(GREEN)와 회색 상태(GRAY)를 나누고 GREEN이 먼저 오도록 정렬
+        List<GetRecentUploadFriendsResponse.Friend> greenFriends = responseFriends.stream()
+                .filter(f -> f.status() == GetRecentUploadFriendsResponse.Status.GREEN)
+                .collect(Collectors.toList());
+
+        List<GetRecentUploadFriendsResponse.Friend> grayFriends = responseFriends.stream()
+                .filter(f -> f.status() == GetRecentUploadFriendsResponse.Status.GRAY)
+                .collect(Collectors.toList());
+
+        // greenFriends 먼저, 그 뒤에 grayFriends 합침
+        greenFriends.addAll(grayFriends);
+        return greenFriends;
     }
+
+
 
     private GetRecentUploadFriendsResponse.Me setMyData(long userId, LocalDateTime now) {
         String myProfileImage = userRepository.getImageById(userId);

--- a/src/main/java/org/example/ctrlu/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/controller/TodoController.java
@@ -78,7 +78,7 @@ public class TodoController {
         return new BaseResponse<>(response);
     }
 
-    @GetMapping
+    @GetMapping("/within-24hours")
     public BaseResponse<GetRecentUploadFriendsResponse> getRecentUploadFriends(@RequestParam long userId,
                                                                                @PageableDefault(size = 10, page= 0) Pageable pageable){
         //todo: 인증 구현 후 userId 받아오는 로직 구현 필요

--- a/src/main/java/org/example/ctrlu/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/controller/TodoController.java
@@ -5,10 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.ctrlu.domain.todo.application.TodoService;
 import org.example.ctrlu.domain.todo.dto.request.CompleteTodoRequest;
 import org.example.ctrlu.domain.todo.dto.request.CreateTodoRequest;
-import org.example.ctrlu.domain.todo.dto.response.CreateTodoResponse;
-import org.example.ctrlu.domain.todo.dto.response.GetRecentUploadFriendsResponse;
-import org.example.ctrlu.domain.todo.dto.response.GetTodoResponse;
-import org.example.ctrlu.domain.todo.dto.response.GetTodosResponse;
+import org.example.ctrlu.domain.todo.dto.response.*;
 import org.example.ctrlu.domain.todo.entity.TodoStatus;
 import org.example.ctrlu.global.response.BaseResponse;
 import org.springframework.data.domain.Pageable;
@@ -83,6 +80,15 @@ public class TodoController {
                                                                                @PageableDefault(size = 10, page= 0) Pageable pageable){
         //todo: 인증 구현 후 userId 받아오는 로직 구현 필요
         GetRecentUploadFriendsResponse response = todoService.getRecentUploadFriends(1L, pageable);
+        return new BaseResponse<>(response);
+    }
+
+    @GetMapping("/detail/within-24hours")
+    public BaseResponse<GetRecentUploadTodoResponse> getRecentUploadTodo(@RequestParam long userId,
+                                                                         @RequestParam long targetId,
+                                                                         @RequestParam long nowId){
+        //todo: 인증 구현 후 userId 받아오는 로직 구현 필요
+        GetRecentUploadTodoResponse response = todoService.getRecentUploadTodo(1L, targetId, nowId);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/controller/TodoController.java
@@ -6,6 +6,7 @@ import org.example.ctrlu.domain.todo.application.TodoService;
 import org.example.ctrlu.domain.todo.dto.request.CompleteTodoRequest;
 import org.example.ctrlu.domain.todo.dto.request.CreateTodoRequest;
 import org.example.ctrlu.domain.todo.dto.response.CreateTodoResponse;
+import org.example.ctrlu.domain.todo.dto.response.GetRecentUploadFriendsResponse;
 import org.example.ctrlu.domain.todo.dto.response.GetTodoResponse;
 import org.example.ctrlu.domain.todo.dto.response.GetTodosResponse;
 import org.example.ctrlu.domain.todo.entity.TodoStatus;
@@ -74,6 +75,14 @@ public class TodoController {
         //todo: 인증 구현 후 userId 받아오는 로직 구현 필요
         if(!target.equals("me") && !target.equals("friend")) throw new IllegalArgumentException("잘못된 접근입니다.");
         GetTodosResponse response = todoService.getTodos(1L, target, status, pageable);
+        return new BaseResponse<>(response);
+    }
+
+    @GetMapping
+    public BaseResponse<GetRecentUploadFriendsResponse> getRecentUploadFriends(@RequestParam long userId,
+                                                                               @PageableDefault(size = 10, page= 0) Pageable pageable){
+        //todo: 인증 구현 후 userId 받아오는 로직 구현 필요
+        GetRecentUploadFriendsResponse response = todoService.getRecentUploadFriends(1L, pageable);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/dto/response/GetRecentUploadFriendsResponse.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/dto/response/GetRecentUploadFriendsResponse.java
@@ -1,5 +1,6 @@
 package org.example.ctrlu.domain.todo.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record GetRecentUploadFriendsResponse(

--- a/src/main/java/org/example/ctrlu/domain/todo/dto/response/GetRecentUploadFriendsResponse.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/dto/response/GetRecentUploadFriendsResponse.java
@@ -22,6 +22,6 @@ public record GetRecentUploadFriendsResponse(
     ) {}
 
     public enum Status {
-        GRAY, GREEN
+        GRAY, NONE, GREEN
     }
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/dto/response/GetRecentUploadFriendsResponse.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/dto/response/GetRecentUploadFriendsResponse.java
@@ -1,0 +1,27 @@
+package org.example.ctrlu.domain.todo.dto.response;
+
+import java.util.List;
+
+public record GetRecentUploadFriendsResponse(
+        Me me,
+        List<Friend> friends,
+        int totalPageCount,
+        int totalElementCount
+) {
+
+    public record Me(
+            long id,
+            String profileImage,
+            Status status
+    ) {}
+
+    public record Friend(
+            long id,
+            String profileImage,
+            Status status
+    ) {}
+
+    public enum Status {
+        GRAY, GREEN
+    }
+}

--- a/src/main/java/org/example/ctrlu/domain/todo/dto/response/GetRecentUploadTodoResponse.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/dto/response/GetRecentUploadTodoResponse.java
@@ -1,0 +1,34 @@
+package org.example.ctrlu.domain.todo.dto.response;
+
+import org.example.ctrlu.domain.todo.entity.Todo;
+import org.example.ctrlu.domain.todo.entity.TodoStatus;
+import org.example.ctrlu.domain.todo.util.DurationTimeCalculator;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record GetRecentUploadTodoResponse(
+        String title,
+        String startImage,
+        String endImage,
+        LocalTime challengeTime,
+        int durationTime,
+        TodoStatus status,
+        Long nextId,
+        Long prevId,
+        int totalCount
+) {
+    public static GetRecentUploadTodoResponse from(LocalDateTime now, Todo todo, Long prevId, Long nextId, int totalCount) {
+        return new GetRecentUploadTodoResponse(
+                todo.getTitle(),
+                todo.getStartImage(),
+                todo.getEndImage(),
+                todo.getChallengeTime(),
+                DurationTimeCalculator.calculate(todo, now),
+                todo.getStatus(),
+                nextId,
+                prevId,
+                totalCount
+        );
+    }
+}

--- a/src/main/java/org/example/ctrlu/domain/todo/entity/Todo.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/entity/Todo.java
@@ -62,8 +62,4 @@ public class Todo extends BaseEntity {
 	public void giveUp() {
 		this.status = TodoStatus.GIVEN_UP;
 	}
-
-	public void delete() {
-		this.status = TodoStatus.DELETED;
-	}
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/entity/TodoStatus.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/entity/TodoStatus.java
@@ -1,5 +1,5 @@
 package org.example.ctrlu.domain.todo.entity;
 
 public enum TodoStatus {
-    IN_PROGRESS, COMPLETED, GIVEN_UP, DELETED
+    IN_PROGRESS, COMPLETED, GIVEN_UP
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/exception/TodoErrorCode.java
@@ -14,7 +14,8 @@ public enum TodoErrorCode implements ErrorCode {
 	NOT_IN_PROGRESS_TODO(HttpStatus.BAD_REQUEST.value(), "T003", "진행 중인 할 일이 아닙니다."),
 	NOT_YOUR_TODO(HttpStatus.BAD_REQUEST.value(), "T004", "본인의 할 일이 아닙니다."),
 	FAIL_TO_GET_TODO(HttpStatus.BAD_REQUEST.value(), "T005", "조회할 수 없는 할 일입니다."),
-	FAIL_TO_GET_FRIEND_TODOS(HttpStatus.BAD_REQUEST.value(), "T006", "친구는 진행 중인 할 일 목록만 조회 가능합니다." );
+	FAIL_TO_GET_FRIEND_TODOS(HttpStatus.BAD_REQUEST.value(), "T006", "친구는 진행 중인 할 일 목록만 조회 가능합니다." ),
+	NOT_TARGET_TODO(HttpStatus.BAD_REQUEST.value(), "T007", "친구의 할 일이 아닙니다.");
 
 	private final int status;
 	private final String code;

--- a/src/main/java/org/example/ctrlu/domain/todo/exception/TodoErrorCode.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/exception/TodoErrorCode.java
@@ -15,7 +15,8 @@ public enum TodoErrorCode implements ErrorCode {
 	NOT_YOUR_TODO(HttpStatus.BAD_REQUEST.value(), "T004", "본인의 할 일이 아닙니다."),
 	FAIL_TO_GET_TODO(HttpStatus.BAD_REQUEST.value(), "T005", "조회할 수 없는 할 일입니다."),
 	FAIL_TO_GET_FRIEND_TODOS(HttpStatus.BAD_REQUEST.value(), "T006", "친구는 진행 중인 할 일 목록만 조회 가능합니다." ),
-	NOT_TARGET_TODO(HttpStatus.BAD_REQUEST.value(), "T007", "친구의 할 일이 아닙니다.");
+	NOT_TARGET_TODO(HttpStatus.BAD_REQUEST.value(), "T007", "친구의 할 일이 아닙니다."),
+	NO_RECENT_TODO(HttpStatus.BAD_REQUEST.value(), "T008", "24시간 내 등록된 할 일이 없습니다.");
 
 	private final int status;
 	private final String code;

--- a/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
@@ -37,4 +37,6 @@ public interface TodoRepository extends JpaRepository<Todo,Long> {
     int countFriendsWithRecentTodos(
             @Param("friendIds") List<Long> friendIds,
             @Param("since") LocalDateTime since);
+
+    List<Todo> findByUserIdAndCreatedAtAfter(Long userId, LocalDateTime createdAtAfter);
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
@@ -51,9 +51,6 @@ public interface TodoRepository extends JpaRepository<Todo,Long> {
             @Param("friendIds") List<Long> friendIds,
             @Param("since") LocalDateTime since);
 
-
-    List<Todo> findByUserIdAndCreatedAtAfterAndStatusNot(Long userId, LocalDateTime createdAtAfter, TodoStatus status);
-
     @Query("""
         SELECT t FROM Todo t
         WHERE t.user.id = :targetId
@@ -67,4 +64,5 @@ public interface TodoRepository extends JpaRepository<Todo,Long> {
             @Param("excludedStatus") TodoStatus todoStatus
     );
 
+    boolean existsByUserIdAndCreatedAtAfterAndStatusNot(long userId, LocalDateTime localDateTime, TodoStatus todoStatus);
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
@@ -53,4 +53,13 @@ public interface TodoRepository extends JpaRepository<Todo,Long> {
 
 
     List<Todo> findByUserIdAndCreatedAtAfterAndStatusNot(Long userId, LocalDateTime createdAtAfter, TodoStatus status);
+
+    @Query("""
+    SELECT t FROM Todo t
+    WHERE t.user.id = :targetId
+    AND t.createdAt >= :timeLimit
+    AND t.status <> :excludedStatus
+    ORDER BY t.createdAt ASC
+    """)
+    List<Todo> findAllRecentTodosByUserId(long targetId, LocalDateTime localDateTime, TodoStatus todoStatus);
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
@@ -6,11 +6,35 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TodoRepository extends JpaRepository<Todo,Long> {
     Page<Todo> findAllByUserIdAndStatus(Long userId, TodoStatus status, Pageable pageable);
     List<Todo> findAllByUserIdAndStatus(Long userId, TodoStatus status);
     Page<Todo> findAllByUserIdInAndStatus(List<Long> friendIds, TodoStatus status, Pageable pageable);
+
+    @Query(value = """
+    SELECT *
+    FROM (
+        SELECT t.*, ROW_NUMBER() OVER (PARTITION BY t.user_id ORDER BY t.created_at DESC) AS rn
+        FROM todo t WHERE t.user_id IN (:friendIds) AND t.created_at >= :since) ranked
+    WHERE ranked.rn = 1 ORDER BY ranked.created_at DESC LIMIT :limit OFFSET :offset
+    """, nativeQuery = true)
+    List<Todo> findPagedLatestTodoPerFriend(
+            @Param("friendIds") List<Long> friendIds,
+            @Param("since") LocalDateTime since,
+            @Param("limit") int limit,
+            @Param("offset") int offset);
+
+
+    @Query(value = """
+    SELECT COUNT(*) FROM (
+        SELECT user_id FROM todo WHERE user_id IN (:friendIds) AND created_at >= :since GROUP BY user_id) AS grouped
+    """, nativeQuery = true)
+    int countFriendsWithRecentTodos(
+            @Param("friendIds") List<Long> friendIds,
+            @Param("since") LocalDateTime since);
 }

--- a/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/todo/repository/TodoRepository.java
@@ -55,11 +55,16 @@ public interface TodoRepository extends JpaRepository<Todo,Long> {
     List<Todo> findByUserIdAndCreatedAtAfterAndStatusNot(Long userId, LocalDateTime createdAtAfter, TodoStatus status);
 
     @Query("""
-    SELECT t FROM Todo t
-    WHERE t.user.id = :targetId
-    AND t.createdAt >= :timeLimit
-    AND t.status <> :excludedStatus
-    ORDER BY t.createdAt ASC
-    """)
-    List<Todo> findAllRecentTodosByUserId(long targetId, LocalDateTime localDateTime, TodoStatus todoStatus);
+        SELECT t FROM Todo t
+        WHERE t.user.id = :targetId
+        AND t.createdAt >= :timeLimit
+        AND t.status <> :excludedStatus
+        ORDER BY t.createdAt ASC
+        """)
+    List<Todo> findAllRecentTodosByUserId(
+            @Param("targetId") long targetId,
+            @Param("timeLimit") LocalDateTime localDateTime,
+            @Param("excludedStatus") TodoStatus todoStatus
+    );
+
 }

--- a/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
 	Optional<User> findByVerifyToken(String verifyToken);
+
+    String getImageById(Long friendId);
 }

--- a/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.example.ctrlu.domain.user.entity.User;
 import org.example.ctrlu.domain.user.entity.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
@@ -14,5 +15,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByIdAndStatus(Long userId, UserStatus status);
 
 	@Query("SELECT u.image FROM User u WHERE u.id = :id")
-    String getImageById(Long id);
+    String getImageById(@Param("id") Long id);
 }

--- a/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
@@ -11,6 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
 	Optional<User> findByEmailAndStatus(String email, UserStatus status);
 	Optional<User> findByVerifyToken(String verifyToken);
+	Optional<User> findByIdAndStatus(Long userId, UserStatus status);
 
 	@Query("SELECT u.image FROM User u WHERE u.id = :id")
     String getImageById(Long id);

--- a/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/ctrlu/domain/user/repository/UserRepository.java
@@ -4,10 +4,12 @@ import java.util.Optional;
 
 import org.example.ctrlu.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
 	Optional<User> findByVerifyToken(String verifyToken);
 
-    String getImageById(Long friendId);
+	@Query("SELECT u.image FROM User u WHERE u.id = :id")
+    String getImageById(Long id);
 }

--- a/src/main/java/org/example/ctrlu/global/config/SecutiryConfig.java
+++ b/src/main/java/org/example/ctrlu/global/config/SecutiryConfig.java
@@ -38,13 +38,8 @@ public class SecutiryConfig {
 		http
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/auth/**").permitAll()
+				.requestMatchers("/**").permitAll()
 				.anyRequest().authenticated()
-			)
-			.authenticationProvider(jwtAuthenticationProvider)
-			.addFilterBefore(
-				new JwtFilter(authenticationConfiguration.getAuthenticationManager()),
-				UsernamePasswordAuthenticationFilter.class
 			);
 
 		return http.build();

--- a/src/main/java/org/example/ctrlu/global/config/SecutiryConfig.java
+++ b/src/main/java/org/example/ctrlu/global/config/SecutiryConfig.java
@@ -38,8 +38,13 @@ public class SecutiryConfig {
 		http
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/**").permitAll()
+				.requestMatchers("/auth/**").permitAll()
 				.anyRequest().authenticated()
+			)
+			.authenticationProvider(jwtAuthenticationProvider)
+			.addFilterBefore(
+				new JwtFilter(authenticationConfiguration.getAuthenticationManager()),
+				UsernamePasswordAuthenticationFilter.class
 			);
 
 		return http.build();

--- a/src/main/java/org/example/ctrlu/infra/redis/RedisConfig.java
+++ b/src/main/java/org/example/ctrlu/infra/redis/RedisConfig.java
@@ -34,8 +34,16 @@ public class RedisConfig extends CachingConfigurerSupport {
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory){
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        // Key와 Value의 직렬화 방식을 설정
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // Value를 단순한 String 타입으로 직렬화하여 저장
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
         return redisTemplate;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,7 @@ spring:
   jpa:
     defer-datasource-initialization: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,8 @@
+CREATE TABLE IF NOT EXISTS healthy (
+                                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                       name VARCHAR(255)
+    );
+
 INSERT INTO healthy (name)
 SELECT val FROM (
                     SELECT '걷기' AS val

--- a/src/test/java/org/example/ctrlu/config/TestRedisConfig.java
+++ b/src/test/java/org/example/ctrlu/config/TestRedisConfig.java
@@ -9,6 +9,6 @@ public class TestRedisConfig {
     static {
         REDIS_CONTAINER = new GenericContainer<>("redis:7-alpine")
                 .withExposedPorts(6379);
-        //REDIS_CONTAINER.start();
+        REDIS_CONTAINER.start();
     }
 }

--- a/src/test/java/org/example/ctrlu/domain/todo/application/ChangeTodoStatusServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/ChangeTodoStatusServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.Clock;
@@ -43,6 +44,7 @@ public class ChangeTodoStatusServiceTest {
     private UserRepository userRepository;
     private AwsS3Service awsS3Service;
     private FriendShipRepository friendShipRepository;
+    private RedisTemplate<String, Object> redisTemplate;
 
     private final long userId = 1L;
     private final long todoId = 100L;
@@ -56,10 +58,12 @@ public class ChangeTodoStatusServiceTest {
         userRepository = mock(UserRepository.class);
         awsS3Service = mock(AwsS3Service.class);
         friendShipRepository = mock(FriendShipRepository.class);
+        redisTemplate = mock(RedisTemplate.class);
+
         Clock fixedClock = Clock.fixed(
                 LocalDateTime.of(2025, 5, 26, 10, 0).atZone(ZoneId.systemDefault()).toInstant(),
                 ZoneId.systemDefault());
-        todoService = new TodoService(todoRepository, userRepository, awsS3Service, friendShipRepository, fixedClock);
+        todoService = new TodoService(todoRepository, userRepository, awsS3Service, friendShipRepository, fixedClock, redisTemplate);
 
         user = User.builder().nickname("닉네임").email("test@gmail.com").password("pass").build();
         todo = mock(Todo.class);

--- a/src/test/java/org/example/ctrlu/domain/todo/application/ChangeTodoStatusServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/ChangeTodoStatusServiceTest.java
@@ -36,7 +36,7 @@ public class ChangeTodoStatusServiceTest {
     /**
      * 할 일 완료(포기) 테스트 시나리오
      * - 진행 중인 할 일 성공
-     * - 이미 완료/포기/삭제한 할 일 실패
+     * - 이미 완료/포기한 할 일 실패
      */
 
     private TodoService todoService;
@@ -93,8 +93,8 @@ public class ChangeTodoStatusServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(value = TodoStatus.class, names = {"COMPLETED", "GIVEN_UP", "DELETED"})
-        @DisplayName("이미 완료/포기/삭제된 할 일 완료 시 실패")
+        @EnumSource(value = TodoStatus.class, names = {"COMPLETED", "GIVEN_UP"})
+        @DisplayName("이미 완료/포기된 할 일 완료 시 실패")
         void complete_invalidStatus_fail(TodoStatus status) {
             // given
             given(todo.getStatus()).willReturn(status);
@@ -127,8 +127,8 @@ public class ChangeTodoStatusServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(value = TodoStatus.class, names = {"COMPLETED", "GIVEN_UP", "DELETED"})
-        @DisplayName("이미 완료/포기/삭제된 할 일 포기 시 실패")
+        @EnumSource(value = TodoStatus.class, names = {"COMPLETED", "GIVEN_UP"})
+        @DisplayName("이미 완료/포기된 할 일 포기 시 실패")
         void giveUp_invalidStatus_fail(TodoStatus status) {
             // given
             given(todo.getStatus()).willReturn(status);

--- a/src/test/java/org/example/ctrlu/domain/todo/application/CreateTodoServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/CreateTodoServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -47,6 +48,7 @@ public class CreateTodoServiceTest {
     private AwsS3Service awsS3Service;
     private TodoService todoService;
     private FriendShipRepository friendShipRepository;
+    private RedisTemplate<String, Object> redisTemplate;
 
     private final long userId = 1L;
     private final String title = "할 일 제목";
@@ -68,10 +70,11 @@ public class CreateTodoServiceTest {
         userRepository = mock(UserRepository.class);
         awsS3Service = mock(AwsS3Service.class);
         friendShipRepository = mock(FriendShipRepository.class);
+        redisTemplate = mock(RedisTemplate.class);
         Clock fixedClock = Clock.fixed(
                 LocalDateTime.of(2025, 5, 26, 10, 0).atZone(ZoneId.systemDefault()).toInstant(),
                 ZoneId.systemDefault());
-        todoService = new TodoService(todoRepository, userRepository, awsS3Service, friendShipRepository, fixedClock);
+        todoService = new TodoService(todoRepository, userRepository, awsS3Service, friendShipRepository, fixedClock, redisTemplate);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(awsS3Service.uploadImage(startImage)).willReturn(uploadedImageUrl);

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadFriendsServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadFriendsServiceTest.java
@@ -60,7 +60,7 @@ public class GetRecentUploadFriendsServiceTest {
 
     private User me;
     private User friend;
-    private static final String REDIS_KEY_PREFIX = "story:seen:";
+    private static final String REDIS_KEY_PREFIX = "recentTodo:seen:";
     public static final String TODO_TITLE = "할 일 제목";
     public static final LocalTime TODO_CHALLENGE_TIME = LocalTime.of(10, 30);
     public static final String TEST_IMAGE = "test-image.png";

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadFriendsServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadFriendsServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
@@ -33,8 +34,8 @@ import java.time.LocalTime;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-@Testcontainers
 @SpringBootTest
+@Testcontainers
 @Transactional
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadFriendsServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadFriendsServiceTest.java
@@ -1,0 +1,265 @@
+package org.example.ctrlu.domain.todo.application;
+
+
+import org.example.ctrlu.config.TestMySQLConfig;
+import org.example.ctrlu.config.TestRedisConfig;
+import org.example.ctrlu.domain.friendship.entity.Friendship;
+import org.example.ctrlu.domain.friendship.repository.FriendShipRepository;
+import org.example.ctrlu.domain.todo.dto.response.GetRecentUploadFriendsResponse;
+import org.example.ctrlu.domain.todo.entity.Todo;
+import org.example.ctrlu.domain.todo.repository.TodoRepository;
+import org.example.ctrlu.domain.user.entity.User;
+import org.example.ctrlu.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Testcontainers
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class GetRecentUploadFriendsServiceTest {
+    /**
+     * 24시간 내에 할 일 등록된 친구 목록 조회 테스트 시나리오
+     * - 친구가 없을 때 응답 성공
+     * - 24시간 내에 내가 올린 할 일이 없을 때 응답 성공
+     * - 24시간 내에 올린 친구가 없을 때 응답 성공
+     * - 24시간 내에 올린 친구가 있고, Redis에 본 이력이 없는 경우 GREEN으로 응답 성공
+     * - 24시간 내에 올린 친구가 있고, Redis에 본 이력이 있고, 새로 올린 경우 GREEN으로 응답 성공
+     * - 24시간 내에 올린 친구가 있고, Redis에 본 이력이 있고, 그게 가장 최근인 경우 GRAY로 응답 성공
+     * - createdAt 내림차순으로 정렬 성공
+     */
+
+    @Autowired private TodoService todoService;
+    @Autowired private TodoRepository todoRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private FriendShipRepository friendShipRepository;
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+
+    private User me;
+    private User friend;
+    private static final String REDIS_KEY_PREFIX = "story:seen:";
+    public static final String TODO_TITLE = "할 일 제목";
+    public static final LocalTime TODO_CHALLENGE_TIME = LocalTime.of(10, 30);
+    public static final String TEST_IMAGE = "test-image.png";
+
+    static final MySQLContainer<?> mySQLContainer = TestMySQLConfig.MYSQL_CONTAINER;
+    static final GenericContainer<?> redisContainer = TestRedisConfig.REDIS_CONTAINER;
+
+    @DynamicPropertySource
+    public static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mySQLContainer::getUsername);
+        registry.add("spring.datasource.password", mySQLContainer::getPassword);
+        registry.add("spring.datasource.driver-class-name", mySQLContainer::getDriverClassName);
+
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", redisContainer::getExposedPorts);
+    }
+
+    @BeforeEach
+    void setUp() {
+        todoRepository.deleteAll();
+        friendShipRepository.deleteAll();
+        userRepository.deleteAll();
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+
+        me = userRepository.save(User.builder()
+                .nickname("나")
+                .email("me@ctrlu.com")
+                .password("pw")
+                .build());
+
+        friend = userRepository.save(User.builder()
+                .nickname("친구")
+                .email("friend@ctrlu.com")
+                .password("pw")
+                .build());
+    }
+
+    @Test
+    @DisplayName("24시간 내 생성한 할 일이 없을 때 응답")
+    void getRecentUploadFriends_noMyTodo_returnsNull() {
+        //given
+        Todo todo = todoRepository.save(Todo.builder()
+                .user(friend)
+                .title(TODO_TITLE)
+                .challengeTime(TODO_CHALLENGE_TIME)
+                .startImage(TEST_IMAGE)
+                .build());
+        ReflectionTestUtils.setField(todo,"createdAt",LocalDateTime.now().minusHours(25));
+        todoRepository.save(todo);
+
+        // when
+        GetRecentUploadFriendsResponse response = todoService.getRecentUploadFriends(me.getId(), PageRequest.of(0, 10));
+
+        // then
+        assertThat(response.me().status()).isEqualTo(GetRecentUploadFriendsResponse.Status.NONE);
+    }
+
+    @Test
+    @DisplayName("친구가 없을 때 응답")
+    void getRecentUploadFriends_noFriend_returnsNull() {
+        // when
+        GetRecentUploadFriendsResponse response = todoService.getRecentUploadFriends(me.getId(), PageRequest.of(0, 10));
+
+        // then
+        assertThat(response.friends()).hasSize(0);
+        assertThat(response.totalElementCount()).isEqualTo(0);
+        assertThat(response.totalPageCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("본 이력이 없으면 GREEN 응답")
+    void getRecentUploadFriends_notSeen_returnsGreen() {
+        // given
+        Friendship friendShip = Friendship.builder().fromUser(me).toUser(friend).build();
+        friendShip.accept();
+        friendShipRepository.save(friendShip);
+        todoRepository.save(Todo.builder()
+                .user(friend)
+                .title(TODO_TITLE)
+                .challengeTime(TODO_CHALLENGE_TIME)
+                .startImage(TEST_IMAGE)
+                .build());
+
+        // when
+        GetRecentUploadFriendsResponse response = todoService.getRecentUploadFriends(me.getId(), PageRequest.of(0, 10));
+
+        // then
+        assertThat(response.friends()).hasSize(1);
+        assertThat(response.friends().get(0).status()).isEqualTo(GetRecentUploadFriendsResponse.Status.GREEN);
+        assertThat(response.totalElementCount()).isEqualTo(1);
+        assertThat(response.totalPageCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("가장 최근 todoId와 본 todoId가 같으면 GRAY 응답")
+    void getRecentUploadFriends_alreadySeen_returnsGray() {
+        // given
+        Friendship friendShip = Friendship.builder().fromUser(me).toUser(friend).build();
+        friendShip.accept();
+        friendShipRepository.save(friendShip);
+
+        Todo todo = todoRepository.save(Todo.builder()
+                .user(friend)
+                .title(TODO_TITLE)
+                .challengeTime(TODO_CHALLENGE_TIME)
+                .startImage(TEST_IMAGE)
+                .build());
+
+        String redisKey = REDIS_KEY_PREFIX + me.getId();
+        redisTemplate.opsForHash().put(redisKey, String.valueOf(friend.getId()), String.valueOf(todo.getId()));
+
+        // when
+        GetRecentUploadFriendsResponse response = todoService.getRecentUploadFriends(me.getId(), PageRequest.of(0, 10));
+
+        // then
+        assertThat(response.friends()).hasSize(1);
+        assertThat(response.friends().get(0).status()).isEqualTo(GetRecentUploadFriendsResponse.Status.GRAY);
+    }
+
+    @Test
+    @DisplayName("본 이력이 있고 최신보다 작으면 GREEN 응답")
+    void getRecentUploadFriends_seenOldTodo_returnsGreen() {
+        // given
+        Friendship friendShip = Friendship.builder().fromUser(me).toUser(friend).build();
+        friendShip.accept();
+        friendShipRepository.save(friendShip);
+
+        Todo oldTodo = Todo.builder()
+                .user(friend)
+                .title(TODO_TITLE)
+                .challengeTime(TODO_CHALLENGE_TIME)
+                .startImage(TEST_IMAGE)
+                .build();
+        ReflectionTestUtils.setField(oldTodo,"createdAt",LocalDateTime.now().minusHours(10));
+        todoRepository.save(oldTodo);
+
+        Todo newTodo = Todo.builder()
+                .user(friend)
+                .title(TODO_TITLE)
+                .challengeTime(TODO_CHALLENGE_TIME)
+                .startImage(TEST_IMAGE)
+                .build();
+        ReflectionTestUtils.setField(newTodo,"createdAt",LocalDateTime.now().minusHours(1));
+        todoRepository.save(newTodo);
+
+        String redisKey = REDIS_KEY_PREFIX + me.getId();
+        redisTemplate.opsForHash().put(redisKey, String.valueOf(friend.getId()), String.valueOf(oldTodo.getId()));
+
+        // when
+        GetRecentUploadFriendsResponse response = todoService.getRecentUploadFriends(me.getId(), PageRequest.of(0, 10));
+
+        // then
+        assertThat(response.friends()).hasSize(1);
+        assertThat(response.friends().get(0).status()).isEqualTo(GetRecentUploadFriendsResponse.Status.GREEN);
+    }
+
+    @Test
+    @DisplayName("createdAt 내림차순으로 응답")
+    void getRecentUploadFriends_desc_createdAt() {
+        // given
+        Friendship friendShip = Friendship.builder().fromUser(me).toUser(friend).build();
+        friendShip.accept();
+        friendShipRepository.save(friendShip);
+
+        User friend2 = userRepository.save(User.builder()
+                .nickname("친구2")
+                .email("friend2@ctrlu.com")
+                .password("pw")
+                .build());
+        Friendship friendShip2 = Friendship.builder().fromUser(me).toUser(friend2).build();
+        friendShip2.accept();
+        friendShipRepository.save(friendShip2);
+
+        Todo firstUploadFriendTodo = Todo.builder()
+                .user(friend)
+                .title(TODO_TITLE)
+                .challengeTime(TODO_CHALLENGE_TIME)
+                .startImage(TEST_IMAGE)
+                .build();
+        ReflectionTestUtils.setField(firstUploadFriendTodo,"createdAt",LocalDateTime.now().minusHours(10));
+        todoRepository.save(firstUploadFriendTodo);
+
+        Todo secondUploadFriendTodo = Todo.builder()
+                .user(friend2)
+                .title(TODO_TITLE)
+                .challengeTime(TODO_CHALLENGE_TIME)
+                .startImage(TEST_IMAGE)
+                .build();
+        ReflectionTestUtils.setField(secondUploadFriendTodo,"createdAt",LocalDateTime.now().minusHours(1));
+        todoRepository.save(secondUploadFriendTodo);
+
+        // when
+        GetRecentUploadFriendsResponse response = todoService.getRecentUploadFriends(me.getId(), PageRequest.of(0, 10));
+
+        // then
+        assertThat(response.friends()).hasSize(2);
+        assertThat(response.friends().get(0).id()).isEqualTo(friend2.getId());
+        assertThat(response.friends().get(1).id()).isEqualTo(friend.getId());
+        assertThat(response.totalElementCount()).isEqualTo(2);
+        assertThat(response.totalPageCount()).isEqualTo(1);
+    }
+
+}

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadTodoServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadTodoServiceTest.java
@@ -1,0 +1,234 @@
+package org.example.ctrlu.domain.todo.application;
+
+import org.example.ctrlu.config.TestMySQLConfig;
+import org.example.ctrlu.config.TestRedisConfig;
+import org.example.ctrlu.domain.friendship.entity.Friendship;
+import org.example.ctrlu.domain.friendship.repository.FriendShipRepository;
+import org.example.ctrlu.domain.todo.dto.response.GetRecentUploadTodoResponse;
+import org.example.ctrlu.domain.todo.entity.Todo;
+import org.example.ctrlu.domain.todo.entity.TodoStatus;
+import org.example.ctrlu.domain.todo.exception.TodoErrorCode;
+import org.example.ctrlu.domain.todo.exception.TodoException;
+import org.example.ctrlu.domain.todo.repository.TodoRepository;
+import org.example.ctrlu.domain.user.entity.User;
+import org.example.ctrlu.domain.user.repository.UserRepository;
+import org.example.ctrlu.global.s3.AwsS3Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.com.google.common.reflect.Reflection;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest
+@Testcontainers
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class GetRecentUploadTodoServiceTest {
+
+    /**
+     * 24시간 내에 등록된 할 일 상세 조회 테스트 시나리오
+     * - 초기 요청 + 본 이력이 없는 경우
+     * - 초기 요청 + 본 이력이 있지만 유효하지 않은 경우
+     * - 초기 요청 + 본 이력이 유효하고 마지막 커서인 경우
+     * - 초기 요청 + 본 이력이 유효하고 마지막 커서가 아닌 경우
+     * - 다음 커서 요청 + 본 이력이 없는 경우
+     * - 다음 커서 요청 + 본 이력이 있지만 갱신할 필요가 없는 경우
+     * - 다음 커서 요청 + 본 이력이 유효하고 갱신해야하는 경우
+     * - 유효하지 않은 커서 요청인 경우
+     */
+
+    @Autowired private TodoRepository todoRepository;
+    @Autowired private TodoService todoService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private FriendShipRepository friendShipRepository;
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+
+    public static final LocalTime TODO_CHALLENGE_TIME = LocalTime.of(10, 30);
+    public static final String TEST_IMAGE = "test-image.png";
+
+    private long userId ;
+    private long targetId;
+    private long firstTodoId;
+    private long secondTodoId;
+    private long thirdTodoId;
+
+    private String redisKey;
+
+    private User user;
+    private User target;
+    private Todo firstTodo;
+    private Todo secondTodo;
+    private Todo thirdTodo;
+
+    static final MySQLContainer<?> mySQLContainer = TestMySQLConfig.MYSQL_CONTAINER;
+    static final GenericContainer<?> redisContainer = TestRedisConfig.REDIS_CONTAINER;
+
+    @DynamicPropertySource
+    public static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mySQLContainer::getUsername);
+        registry.add("spring.datasource.password", mySQLContainer::getPassword);
+        registry.add("spring.datasource.driver-class-name", mySQLContainer::getDriverClassName);
+
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", redisContainer::getExposedPorts);
+    }
+
+    @BeforeEach
+    void setUp() {
+        todoRepository.deleteAll();
+        friendShipRepository.deleteAll();
+        userRepository.deleteAll();
+        Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().flushAll();
+
+        user = User.builder().nickname("유저 닉네임").email("test@gmail.com").password("pass").build();
+        target = User.builder().nickname("타겟 닉네임").email("target@gmail.com").password("pass").build();
+
+        userId = userRepository.save(user).getId();
+        targetId = userRepository.save(target).getId();
+        Friendship friendShip = Friendship.builder().fromUser(user).toUser(target).build();
+        friendShip.accept();
+        friendShipRepository.save(friendShip);
+        redisKey = "recentTodo:seen:" + userId;
+
+        firstTodo = Todo.builder().title("첫 번째 할일").challengeTime(TODO_CHALLENGE_TIME).startImage(TEST_IMAGE).user(target).build();
+        secondTodo = Todo.builder().title("두 번째 할일").challengeTime(TODO_CHALLENGE_TIME).startImage(TEST_IMAGE).user(target).build();
+        thirdTodo = Todo.builder().title("세 번째 할일").challengeTime(TODO_CHALLENGE_TIME).startImage(TEST_IMAGE).user(target).build();
+
+        firstTodoId = todoRepository.save(firstTodo).getId();
+        secondTodoId = todoRepository.save(secondTodo).getId();
+        thirdTodoId = todoRepository.save(thirdTodo).getId();
+    }
+
+    @Test
+    @DisplayName("초기 요청 - 본 이력이 없는 경우 - firstTodo 반환 + Redis 갱신")
+    void getInitialTodo_noSeenHistory_returnsFirstTodo() {
+        // when
+        GetRecentUploadTodoResponse response = todoService.getRecentUploadTodo(userId, targetId, 0L);
+
+        // then
+        assertThat(response.nextId()).isEqualTo(secondTodoId);
+        assertThat(response.prevId()).isEqualTo(null);
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(redisTemplate.opsForHash().get(redisKey, String.valueOf(targetId))).isEqualTo(String.valueOf(firstTodoId));
+    }
+
+    @Test
+    @DisplayName("초기 요청 - 본 이력 있지만 유효하지 않음 - firstTodo 반환 + Redis 갱신")
+    void getInitialTodo_invalidSeenHistory_returnsFirstTodo() {
+        // given
+        redisTemplate.opsForHash().put(redisKey, String.valueOf(targetId), String.valueOf(999L));
+
+        // when
+        GetRecentUploadTodoResponse response = todoService.getRecentUploadTodo(userId, targetId, 0L);
+
+        System.out.println("테스트" + response.totalCount());
+        // then
+        assertThat(response.nextId()).isEqualTo(secondTodoId);
+        assertThat(response.prevId()).isEqualTo(null);
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(redisTemplate.opsForHash().get(redisKey, String.valueOf(targetId))).isEqualTo(String.valueOf(firstTodoId));
+    }
+
+    @Test
+    @DisplayName("초기 요청 - 본 이력이 이미 가장 최신 - firstTodo 반환 + Redis 변동 없음")
+    void getInitialTodo_validSeenHistory_isLastTodo_returnsFirstAgain() {
+        // given
+        redisTemplate.opsForHash().put(redisKey, String.valueOf(targetId), String.valueOf(thirdTodoId));
+
+        // when
+        GetRecentUploadTodoResponse response = todoService.getRecentUploadTodo(userId, targetId, 0);
+
+        // then
+        assertThat(response.nextId()).isEqualTo(secondTodoId);
+        assertThat(response.prevId()).isEqualTo(null);
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(redisTemplate.opsForHash().get(redisKey, String.valueOf(targetId))).isEqualTo(String.valueOf(thirdTodoId));
+    }
+
+    @Test
+    @DisplayName("초기 요청 - 본 이력이 가장 최신 게 아닌 경우 - 그 다음 할 일 반환 + Redis 갱신")
+    void getInitialTodo_validSeenHistory_notLastTodo_returnsNextTodo() {
+        // given
+        redisTemplate.opsForHash().put(redisKey, String.valueOf(targetId), String.valueOf(firstTodoId));
+
+        // when
+        GetRecentUploadTodoResponse response = todoService.getRecentUploadTodo(userId, targetId, 0);
+
+        // then
+        assertThat(response.nextId()).isEqualTo(thirdTodoId);
+        assertThat(response.prevId()).isEqualTo(firstTodoId);
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(redisTemplate.opsForHash().get(redisKey, String.valueOf(targetId))).isEqualTo(String.valueOf(secondTodoId));
+    }
+
+    @Test
+    @DisplayName("다음 커서 요청 - 본 이력이 없는 경우 - 해당 커서 반환 + Redis 갱신")
+    void getNextTodo_noSeenHistory_returnsNowIdTodoAndUpdatesRedis() {
+        // when
+        GetRecentUploadTodoResponse response = todoService.getRecentUploadTodo(userId, targetId, firstTodoId);
+
+        // then
+        assertThat(response.nextId()).isEqualTo(secondTodoId);
+        assertThat(response.prevId()).isEqualTo(null);
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(redisTemplate.opsForHash().get(redisKey, String.valueOf(targetId))).isEqualTo(String.valueOf(firstTodoId));
+    }
+
+    @Test
+    @DisplayName("다음 커서 요청 - 본 이력이 이미 가장 최신 - Redis 변동 없음")
+    void getNextTodo_seenHistoryNotUpdateNeeded_returnsNowIdTodo() {
+        // given
+        redisTemplate.opsForHash().put(redisKey, String.valueOf(targetId), String.valueOf(thirdTodoId));
+
+        // when
+        GetRecentUploadTodoResponse response = todoService.getRecentUploadTodo(userId, targetId, firstTodoId);
+
+        // then
+        assertThat(response.nextId()).isEqualTo(secondTodoId);
+        assertThat(response.prevId()).isEqualTo(null);
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(redisTemplate.opsForHash().get(redisKey, String.valueOf(targetId))).isEqualTo(String.valueOf(thirdTodoId));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 커서 요청인 경우 예외 발생")
+    void getNextTodo_invalidNowId_throwsException() {
+        // given
+        long invalidTodoId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> todoService.getRecentUploadTodo(userId, targetId, invalidTodoId))
+                .isInstanceOf(TodoException.class)
+                .hasMessageContaining(TodoErrorCode.NOT_FOUND_TODO.getMessage());
+    }
+}

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadTodoServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetRecentUploadTodoServiceTest.java
@@ -151,7 +151,6 @@ public class GetRecentUploadTodoServiceTest {
         // when
         GetRecentUploadTodoResponse response = todoService.getRecentUploadTodo(userId, targetId, 0L);
 
-        System.out.println("테스트" + response.totalCount());
         // then
         assertThat(response.nextId()).isEqualTo(secondTodoId);
         assertThat(response.prevId()).isEqualTo(null);

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetTodoServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetTodoServiceTest.java
@@ -129,18 +129,4 @@ class GetTodoServiceTest {
         assertThat(response.durationTime()).isEqualTo(30 * 60 * 1000);
     }
 
-    @DisplayName("할 일 조회 실패 - 삭제한 할 일")
-    @Test
-    void getTodo_fail_deletedTodo() {
-        // given
-        ReflectionTestUtils.setField(todo, "status", TodoStatus.DELETED);
-        given(todoRepository.findById(todoId)).willReturn(Optional.of(todo));
-
-        // when
-        TodoException exception = assertThrows(TodoException.class, () -> todoService.getTodo(userId, todoId));
-
-        // then
-        assertThat(exception.getMessage()).startsWith(FAIL_TO_GET_TODO.getMessage());
-        assertThat(exception.getMessage()).contains(TodoStatus.DELETED.name());
-    }
 }

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetTodoServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetTodoServiceTest.java
@@ -12,6 +12,7 @@ import org.example.ctrlu.global.s3.AwsS3Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.*;
@@ -44,6 +45,7 @@ class GetTodoServiceTest {
     private AwsS3Service awsS3Service;
     private TodoService todoService;
     private FriendShipRepository friendShipRepository;
+    private RedisTemplate<String, Object> redisTemplate;
 
     public static final User user = User.builder()
             .nickname(USER_NICKNAME)
@@ -61,11 +63,13 @@ class GetTodoServiceTest {
         todoRepository = mock(TodoRepository.class);
         userRepository = mock(UserRepository.class);
         awsS3Service = mock(AwsS3Service.class);
+        redisTemplate = mock(RedisTemplate.class);
+
         friendShipRepository = mock(FriendShipRepository.class);
         Clock fixedClock = Clock.fixed(
                 LocalDateTime.of(2025, 5, 26, 10, 0).atZone(ZoneId.systemDefault()).toInstant(),
                 ZoneId.systemDefault());
-        todoService = new TodoService(todoRepository, userRepository, awsS3Service, friendShipRepository, fixedClock);
+        todoService = new TodoService(todoRepository, userRepository, awsS3Service, friendShipRepository, fixedClock, redisTemplate);
 
         todo = Todo.builder()
                 .title(TODO_TITLE)

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetTodosServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetTodosServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
@@ -52,6 +53,7 @@ public class GetTodosServiceTest {
     private AwsS3Service awsS3Service;
     private FriendShipRepository friendShipRepository;
     private TodoService todoService;
+    private RedisTemplate<String, Object> redisTemplate;
 
     private final long userId = 1L;
     private final User user = User.builder()
@@ -66,9 +68,10 @@ public class GetTodosServiceTest {
         userRepository = mock(UserRepository.class);
         awsS3Service = mock(AwsS3Service.class);
         friendShipRepository = mock(FriendShipRepository.class);
+        redisTemplate = mock(RedisTemplate.class);
 
         Clock fixedClock = Clock.fixed(LocalDateTime.of(2025, 5, 26, 10, 0).atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
-        todoService = new TodoService(todoRepository, userRepository, awsS3Service, friendShipRepository, fixedClock);
+        todoService = new TodoService(todoRepository, userRepository, awsS3Service, friendShipRepository, fixedClock, redisTemplate);
 
         ReflectionTestUtils.setField(user, "id", userId);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));

--- a/src/test/java/org/example/ctrlu/domain/todo/application/GetTodosServiceTest.java
+++ b/src/test/java/org/example/ctrlu/domain/todo/application/GetTodosServiceTest.java
@@ -97,19 +97,6 @@ public class GetTodosServiceTest {
     }
 
     @Test
-    @DisplayName("내 할 일 조회 실패 - 삭제 상태 요청")
-    void getMyTodos_fail_deletedStatus() {
-        // when
-        TodoException exception = assertThrows(TodoException.class, () ->
-                todoService.getTodos(userId, "me", TodoStatus.DELETED, PageRequest.of(0, 10))
-        );
-
-        // then
-        assertThat(exception.getMessage()).startsWith(FAIL_TO_GET_TODO.getMessage());
-        assertThat(exception.getMessage()).contains(TodoStatus.DELETED.name());
-    }
-
-    @Test
     @DisplayName("친구의 할 일 조회 성공 - createdAt 오름차순")
     void getFriendTodos_success_sortedByCreatedAt() {
         // given

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,6 +11,26 @@ spring:
     redis:
       host: localhost
       port: 6379
+  mail:
+    port: 465
+    username: FAKE
+    password: FAKE
+    host: localhost
+    request-uri: FAKE
+    default-encoding: UTF-8
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: false
+          ssl:
+            enable: true
+            trust: FAKE
+        transport:
+          protocol: smtp
+        debug: true
+
 ---
 cloud:
   aws:


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt): 사용자 인증을 위한 jwt 토큰 추가
-->

<!---- Resolves: #(Isuue Number) -->
Resolves #15
closed #15

## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
> 24시간 내 할 일을 등록한 나+친구 목록 조회
- 세 가지의 상태로 나누었습니다.
  - GREEN: 새로 등록된 할 일이 존재
  - GRAY: 모든 할 일을 조회한 상태
  - NONE: 할 일이 없는 상태('나'에게만 존재) 
- 응답
<img width="947" alt="image" src="https://github.com/user-attachments/assets/d0746397-c67e-45f1-83cd-363bd1eb1c32" /> 

> 24시간 내 등록된 할 일 상세 조회
- nowId=0 이면 초기 요청입니다.
- nowId>0 이면 다음 커서 요청입니다.
- 응답
<img width="887" alt="스크린샷 2025-06-05 오후 5 00 51" src="https://github.com/user-attachments/assets/2e661152-761a-4588-85ed-5daddc244f52" />

> 테스트 코드
두 API 모두 MySQL과 Redis의 작업까지 테스트하기 위해 통합 테스트로 진행하였습니다.

## 📝 PR 유형
어떤 변경 사항이 있나요?
기능 추가

## ✔ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 💬 팀원에게 전할 말
<!---- 고민되었던 부분이나 코드 리뷰를 중점적으로 봐주었으면 하는 내용을 작성해주세요. -->
비즈니스 로직 중 빠뜨린 시나리오가 있는지 봐주시면 감사하겠습니당
